### PR TITLE
Remove unnecessary 'Testsuite: autopkgtest' header.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends: debhelper (>= 9), dh-python,
  python3-all, python3-setuptools,
  python3-django, python3-six, python3-django-nose
 X-Python-Version: >=2.7
-Testsuite: autopkgtest
 Standards-Version: 4.1.4
 Homepage: https://github.com/arteria/django-compat
 Vcs-Git: https://github.com/Linaro/pkg-django-compat.git


### PR DESCRIPTION
Remove unnecessary 'Testsuite: autopkgtest' header.

Fixes lintian: unncessary-testsuite-autopkgtest-field
